### PR TITLE
Enable support for a plethora of more DNS types.

### DIFF
--- a/internal/dns/dns.go
+++ b/internal/dns/dns.go
@@ -245,7 +245,7 @@ func ConvertToQType(recordType string) (uint16, error) {
 	if qtype, exists := dns.StringToType[recordType]; exists {
 		return qtype, nil
 	}
-	return 0, fmt.Errorf("unsupported record type: %s", recordType)
+	return 0, fmt.Errorf("unsupported record type %q", recordType)
 }
 
 // createDNSResponse creates a JSON-serializable map from a DNS message.


### PR DESCRIPTION
The current DNS list, although it works, was a bit limiting. Recently I've needed to make a `CAA` query and this tool technically should support it but wasn't available in the list of options.

This PR open the floodgates for all dns query types supported by [`miekg/dns`](https://github.com/miekg/dns).